### PR TITLE
Fix: Resolve TypeScript errors in App, PaymentContext, and usePrintfu…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Token from "./pages/Token";
 import TokenConfirmation from "./pages/TokenConfirmation";
 import Checkout from "./pages/Checkout";
 import PaymentSuccess from "./pages/PaymentSuccess";
+import Admin from "./pages/Admin";
 import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import Auth from "./pages/Auth";

--- a/src/context/PaymentContext.tsx
+++ b/src/context/PaymentContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useState } from 'react';
 import { toast } from "@/hooks/use-toast";
 import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
 
 // Define types for our context
 type PaymentMethod = 'card' | 'crypto';


### PR DESCRIPTION
…l hook

This commit addresses three TypeScript errors:

1.  **TS2304: Cannot find name 'Admin' in src/App.tsx**: Imported the `Admin` component from `./pages/Admin` into `src/App.tsx`.

2.  **TS2304: Cannot find name 'supabase' in src/context/PaymentContext.tsx**: Imported the `supabase` client from `@/integrations/supabase/client` into `src/context/PaymentContext.tsx`.

3.  **TS2589: Type instantiation is excessively deep and possibly infinite in src/hooks/usePrintful.ts**: Defined explicit types for the data returned by the `supabase` query in the `usePrintfulProducts` hook.
    - Imported `Tables` type from `../integrations/supabase/types`.
    - Created a `PrintfulProduct` interface extending `Tables<'products'>` and including an `artists` field of type `Tables<'artists'> | null`.
    - Typed the `useQuery` hook and its `queryFn` to use these explicit types, resolving the type inference issue.